### PR TITLE
Update EDA notebook to import utility modules and reset execution count

### DIFF
--- a/notebooks/EDA.ipynb
+++ b/notebooks/EDA.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -225,6 +225,7 @@
    ],
    "source": [
     "import yfinance as yf\n",
+    "from scripts import utils, config, data, model\n",
     "\n",
     "# Define tickers\n",
     "tickers = ['TSLA', 'BND', 'SPY']\n",


### PR DESCRIPTION
This pull request includes updates to the `notebooks/EDA.ipynb` file to improve the data analysis process by importing additional scripts and resetting the execution count.

Improvements to data analysis:

* [`notebooks/EDA.ipynb`](diffhunk://#diff-1908437e8050de1dc2844ad02e2e66864764b3fae7392cdd1e957c7c213c6bb1R228): Added imports for `utils`, `config`, `data`, and `model` from the `scripts` module to enhance the functionality of the notebook.

Codebase maintenance:

* [`notebooks/EDA.ipynb`](diffhunk://#diff-1908437e8050de1dc2844ad02e2e66864764b3fae7392cdd1e957c7c213c6bb1L5-R5): Reset the `execution_count` to `null` to ensure the notebook runs fresh without pre-executed cells.